### PR TITLE
New rules

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Add the NPM token to the .npmrc file
+echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> "$HOME/.npmrc"
+
+# Publish the package, but only if the current published version is behind the latest version.
+PUBLISHED_VERSION=$(yarn info --json | jq -r '.data."dist-tags".latest')
+PACKAGE_VERSION=$(jq -r '.version' package.json)
+
+if [ "$PACKAGE_VERSION" != "$PUBLISHED_VERSION" ]; then
+  yarn publish || 0
+else
+  echo "The current version ($PACKAGE_VERSION) has not changed. If you would like to deploy a new" \
+    "version, follow the instructions in the readme."
+fi

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -5,5 +5,5 @@
 -
   name: deploy-to-npm
   service: eslint-config-optimum-energy
-  command: scripts/publish.sh
+  command: yarn run publish
   tag: master

--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ module.exports = {
     "comma-style": "warn",
     "computed-property-spacing": "warn",
     "eol-last": "warn",
+    "function-paren-newline": [ "warn", "multiline" ],
     "indent": [ "warn", 2, { "SwitchCase": 1 } ],
     "key-spacing": "warn",
     "keyword-spacing": "warn",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "eslint": "^5.16.0"
   },
   "scripts": {
-    "lint": "eslint -c index.js --max-warnings 0 ."
+    "lint": "eslint -c index.js --max-warnings 0 .",
+    "publish": "bin/publish"
   }
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-# Add the NPM token to the .npmrc file
-echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> "$HOME/.npmrc"
-
-# Publish the package
-npm publish


### PR DESCRIPTION
I've noticed that we're a bit inconsistent in our function arguments style. I've seen all of the following in our code:

```
foo(a, b, c);

foo(
  a,
  b,
  c
)

foo(a,
  b,
  c
)

foo(a,
  b, c)
```

I'd like to simplify this and keep things consistent. I propose we stick with the first two styles—the first when the line is short enough and the second when it's not. There's now a simple ESLint rule for this, so this should simplify things for anyone with an editor that auto formats.

This PR also fixes the publish script, which has had issues in the past.